### PR TITLE
Add dia bar smooth animation and Aero / Aero II duration support

### DIFF
--- a/DelvUI/Interface/WhiteMageHudWindow.cs
+++ b/DelvUI/Interface/WhiteMageHudWindow.cs
@@ -83,15 +83,19 @@ namespace DelvUI.Interface
                 return;
             }
             var dia = target.StatusEffects.FirstOrDefault(o => o.EffectId == 1871 || o.EffectId == 144 || o.EffectId == 143);
-
-            var diaDuration = (int)dia.Duration;
+            var diaCooldown = dia.EffectId == 1871 ? 30f : 18f;
+            var diaDuration = dia.Duration;
             var xOffset = CenterX;
 
             drawList.AddRectFilled(cursorPos, cursorPos + BarSize, EmptyColor["gradientRight"]);
-            drawList.AddRectFilled(cursorPos, cursorPos + new Vector2((BarSize.X / 30) * diaDuration, BarSize.Y), WhmDiaColor["gradientRight"]);
+            drawList.AddRectFilled(cursorPos, cursorPos + new Vector2((BarSize.X / diaCooldown) * diaDuration, BarSize.Y), WhmDiaColor["gradientRight"]);
             drawList.AddRect(cursorPos, cursorPos + BarSize, 0xFF000000);
-            DrawOutlinedText(diaDuration.ToString(CultureInfo.InvariantCulture), new Vector2(cursorPos.X + BarSize.X * diaDuration / 30 - (diaDuration == 30 ? 30 : diaDuration > 3 ? 20 : 0), cursorPos.Y + (BarSize.Y / 2) - 12));
-
+            DrawOutlinedText(string.Format(CultureInfo.InvariantCulture, "{0,2:N0}", diaDuration), // keeps 10 -> 9 from jumping
+                new Vector2(cursorPos.X + BarSize.X * diaDuration / diaCooldown - (diaDuration ==
+                diaCooldown ? diaCooldown :
+                                        diaDuration > 3 ? 20 :
+                                        diaDuration * (20f / 3f)), // smooths transition of counter to the right of the emptying bar
+                cursorPos.Y + (BarSize.Y / 2) - 12));
         }
 
         private void DrawSecondaryResourceBar()


### PR DESCRIPTION
- Fixed discrepancy between built-in timer and Delvui timer.
- Added duration support for Aero and Aero II total duration. Aero and Aero II's duration in 18s, while Dia is 30s. This led to players level < 72 only having their DoT bars ~half filled on a fresh dot.
- Added smooth linear shrinking of remaining DoT time, fixed jumping text, and added an animation to move the counter so that it keeps within the bar boundaries nearing DoT expiration.

All illustrated below.

**Old behavior:**
![Old behavior](https://user-images.githubusercontent.com/969264/131246655-d96fa8d3-56eb-4fbb-891a-96546a3e4882.gif)

**New behavior:**
![New behavior](https://user-images.githubusercontent.com/969264/131246483-5114d749-4422-446d-a8e3-e0c08f992092.gif)
