### PR TITLE
Revert probably acciental removal of SMNs bio

### DIFF
--- a/DelvUI/PluginConfiguration.cs
+++ b/DelvUI/PluginConfiguration.cs
@@ -820,7 +820,13 @@ namespace DelvUI {
                     ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(SmnMiasmaColor.AdjustColor(.1f))
                 },
 
- 
+                [Jobs.SMN * 1000 + 4] = new Dictionary<string, uint> // Bio Bar
+                {
+                    ["base"] = ImGui.ColorConvertFloat4ToU32(SmnBioColor),
+                    ["background"] = ImGui.ColorConvertFloat4ToU32(SmnBioColor.AdjustColor(-.8f)),
+                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(SmnBioColor.AdjustColor(-.1f)),
+                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(SmnBioColor.AdjustColor(.1f))
+                },
 
                 [Jobs.SMN * 1000 + 5] = new Dictionary<string, uint> // Dot Expiry
                 {
@@ -1201,14 +1207,6 @@ namespace DelvUI {
                     ["background"] = ImGui.ColorConvertFloat4ToU32(RDMWDotColor.AdjustColor(-.8f)),
                     ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(RDMWDotColor.AdjustColor(-.1f)),
                     ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(RDMWDotColor.AdjustColor(.1f))
-                },
-
-                [Jobs.SMN] = new Dictionary<string, uint>
-                {
-                    ["base"] = ImGui.ColorConvertFloat4ToU32(JobColorSMN),
-                    ["background"] = ImGui.ColorConvertFloat4ToU32(JobColorSMN.AdjustColor(-.8f)),
-                    ["gradientLeft"] = ImGui.ColorConvertFloat4ToU32(JobColorSMN.AdjustColor(-.1f)),
-                    ["gradientRight"] = ImGui.ColorConvertFloat4ToU32(JobColorSMN.AdjustColor(.1f))
                 },
 
                 [Jobs.RDM] = new Dictionary<string, uint>


### PR DESCRIPTION
In fa69f9e8633d0b38eae9aad017a1a420d13e03b SMN's Bio entry in the color map was removed, while a duplicate of the class color was added elsewhere in the file.

This leads to an error and plugin crash when Bio is cast as the color can't be found. 

This patch reverts those changes.