### PR TITLE
Fix WHM, SCH, and SMN's DoT tracking being overwritten

### DIFF
--- a/DelvUI/Interface/ScholarHudWindow.cs
+++ b/DelvUI/Interface/ScholarHudWindow.cs
@@ -163,7 +163,9 @@ namespace DelvUI.Interface
                 drawList.AddRect(cursorPos, cursorPos + BarSize, 0xFF000000);
                 return;
             }
-            var bio = target.StatusEffects.FirstOrDefault(o => o.EffectId == 179 || o.EffectId == 189 || o.EffectId == 1895);
+            var bio = target.StatusEffects.FirstOrDefault(o => o.EffectId == 179 && o.OwnerId == PluginInterface.ClientState.LocalPlayer.ActorId ||
+                                                               o.EffectId == 189 && o.OwnerId == PluginInterface.ClientState.LocalPlayer.ActorId ||
+                                                               o.EffectId == 1895 && o.OwnerId == PluginInterface.ClientState.LocalPlayer.ActorId);
             var bioDuration = (int)bio.Duration;
             var xOffset = CenterX;
 

--- a/DelvUI/Interface/SummonerHudWindow.cs
+++ b/DelvUI/Interface/SummonerHudWindow.cs
@@ -57,9 +57,12 @@ namespace DelvUI.Interface
 
             var xPadding = 2;
             var barWidth = (SmnDotBarWidth / 2) - 1;
-            var miasma = target.StatusEffects.FirstOrDefault(o => o.EffectId == 1215 || o.EffectId == 180);
-            var bio = target.StatusEffects.FirstOrDefault(o => o.EffectId == 1214 || o.EffectId == 179 || o.EffectId == 189);
-            
+            var miasma = target.StatusEffects.FirstOrDefault(o => o.EffectId == 1215 && o.OwnerId == PluginInterface.ClientState.LocalPlayer.ActorId ||
+                                                                  o.EffectId == 180 && o.OwnerId == PluginInterface.ClientState.LocalPlayer.ActorId);
+            var bio = target.StatusEffects.FirstOrDefault(o => o.EffectId == 1214 && o.OwnerId == PluginInterface.ClientState.LocalPlayer.ActorId ||
+                                                               o.EffectId == 179 && o.OwnerId == PluginInterface.ClientState.LocalPlayer.ActorId ||
+                                                               o.EffectId == 189 && o.OwnerId == PluginInterface.ClientState.LocalPlayer.ActorId);
+
             var miasmaDuration = miasma.Duration;
             var bioDuration = bio.Duration;
 

--- a/DelvUI/Interface/WhiteMageHudWindow.cs
+++ b/DelvUI/Interface/WhiteMageHudWindow.cs
@@ -84,7 +84,9 @@ namespace DelvUI.Interface
                 drawList.AddRect(cursorPos, cursorPos + BarSize, 0xFF000000);
                 return;
             }
-            var dia = target.StatusEffects.FirstOrDefault(o => o.EffectId == 1871 || o.EffectId == 144 || o.EffectId == 143);
+            var dia = target.StatusEffects.FirstOrDefault(o => o.EffectId == 1871 && o.OwnerId == PluginInterface.ClientState.LocalPlayer.ActorId ||
+                                                               o.EffectId == 144 && o.OwnerId == PluginInterface.ClientState.LocalPlayer.ActorId ||
+                                                               o.EffectId == 143 && o.OwnerId == PluginInterface.ClientState.LocalPlayer.ActorId);
             var diaCooldown = dia.EffectId == 1871 ? 30f : 18f;
             var diaDuration = dia.Duration;
             var xOffset = CenterX;


### PR DESCRIPTION
Fix WHM, SCH, and SMN's DoT tracking being confused by other players' equivalent DoTs. 

(Note that #70 must be merged first as it fixes a crashing bug that was introduced in #61, unrelated to this patch).