### PR TITLE
fix: aesthetician (barber) crash

### DIFF
--- a/DelvUI/Interface/HudWindow.cs
+++ b/DelvUI/Interface/HudWindow.cs
@@ -222,20 +222,19 @@ namespace DelvUI.Interface {
                     colors["gradientLeft"], colors["gradientRight"], colors["gradientRight"], colors["gradientLeft"]
                 );
                 drawList.AddRect(cursorPos, cursorPos + BarSize, 0xFF000000);
-
-                var text = Helpers.TextTags.GenerateFormattedTextFromTags(target, PluginConfiguration.TargetBarTextLeft);
-                DrawOutlinedText(text, new Vector2(cursorPos.X + 5 + TargetBarTextLeftXOffset, cursorPos.Y - 22 + TargetBarTextLeftYOffset));
             }
+            
+            var textLeft = Helpers.TextTags.GenerateFormattedTextFromTags(target, PluginConfiguration.TargetBarTextLeft);
+            DrawOutlinedText(textLeft,
+                new Vector2(cursorPos.X + 5 + TargetBarTextLeftXOffset,
+                    cursorPos.Y - 22 + TargetBarTextLeftYOffset));
 
             var textRight = Helpers.TextTags.GenerateFormattedTextFromTags(target, PluginConfiguration.TargetBarTextRight);
             var textRightSize = ImGui.CalcTextSize(textRight);
 
             DrawOutlinedText(textRight,
-                new Vector2(
-                    cursorPos.X + TargetBarWidth - textRightSize.X - 5 + TargetBarTextRightXOffset,
-                    cursorPos.Y - 22 + TargetBarTextRightYOffset
-                )
-            );
+                new Vector2(cursorPos.X + TargetBarWidth - textRightSize.X - 5 + TargetBarTextRightXOffset,
+                    cursorPos.Y - 22 + TargetBarTextRightYOffset));
 
             DrawTargetShield(target, cursorPos, BarSize, true);
             DrawTargetOfTargetBar(target.TargetActorID);

--- a/DelvUI/Plugin.cs
+++ b/DelvUI/Plugin.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
+using Dalamud.Game.ClientState;
 using Dalamud.Game.Command;
 using Dalamud.Plugin;
 using ImGuiNET;
@@ -67,6 +68,12 @@ namespace DelvUI {
         }
 
         private void Draw() {
+            
+            var inCutscene = _pluginInterface.ClientState.Condition[ConditionFlag.WatchingCutscene]
+                             || _pluginInterface.ClientState.Condition[ConditionFlag.WatchingCutscene78]
+                             || _pluginInterface.ClientState.Condition[ConditionFlag.OccupiedInCutSceneEvent]
+                             || _pluginInterface.ClientState.Condition[ConditionFlag.CreatingCharacter];
+
             _pluginInterface.UiBuilder.OverrideGameCursor = false;
             
             _configurationWindow.Draw();
@@ -79,7 +86,9 @@ namespace DelvUI {
                 SwapJobs();
             }
 
-            _hudWindow?.Draw();
+            if (!inCutscene) { 
+                _hudWindow?.Draw();
+            }
 
             if (_fontBuilt) {
                 ImGui.PopFont();


### PR DESCRIPTION
There was a null pointer on the castbar draw while loading into the character customization screen in game. To circumvent this I decided to make a bool check in the draw function inside Plugin.cs. The bool checks the ClientState for specific condition flags. If any return true, the hud is not drawn.